### PR TITLE
Make LuST compatible with SUMO 1.0.1

### DIFF
--- a/scenario/dua.actuated.sumocfg
+++ b/scenario/dua.actuated.sumocfg
@@ -10,8 +10,8 @@ Author: Lara CODECA [codeca@gmail.com]
 
     <input>
         <net-file value="lust.net.xml"/>
-        <route-files value="buslines.rou.xml DUARoutes/local.0.rou.xml DUARoutes/local.1.rou.xml DUARoutes/local.2.rou.xml transit.rou.xml"/>
-        <additional-files value="vtypes.add.xml busstops.add.xml e1detectors.add.xml lust.poly.xml"/>
+        <route-files value="buslines.rou.xml, DUARoutes/local.0.rou.xml, DUARoutes/local.1.rou.xml, DUARoutes/local.2.rou.xml, transit.rou.xml"/>
+        <additional-files value="vtypes.add.xml, busstops.add.xml, e1detectors.add.xml, lust.poly.xml"/>
     </input>
 
     <output>

--- a/scenario/dua.static.sumocfg
+++ b/scenario/dua.static.sumocfg
@@ -10,8 +10,8 @@ Author: Lara CODECA [codeca@gmail.com]
 
     <input>
         <net-file value="lust.net.xml"/>
-        <route-files value="buslines.rou.xml DUARoutes/local.0.rou.xml DUARoutes/local.1.rou.xml DUARoutes/local.2.rou.xml transit.rou.xml"/>
-        <additional-files value="vtypes.add.xml busstops.add.xml e1detectors.add.xml lust.poly.xml tll.static.xml"/>
+        <route-files value="buslines.rou.xml, DUARoutes/local.0.rou.xml, DUARoutes/local.1.rou.xml, DUARoutes/local.2.rou.xml, transit.rou.xml"/>
+        <additional-files value="vtypes.add.xml, busstops.add.xml, e1detectors.add.xml, lust.poly.xml, tll.static.xml"/>
     </input>
 
     <output>

--- a/scenario/due.actuated.sumocfg
+++ b/scenario/due.actuated.sumocfg
@@ -10,8 +10,8 @@ Author: Lara CODECA [codeca@gmail.com]
 
     <input>
         <net-file value="lust.net.xml"/>
-        <route-files value="buslines.rou.xml DUERoutes/local.actuated.0.rou.xml DUERoutes/local.actuated.1.rou.xml DUERoutes/local.actuated.2.rou.xml transit.rou.xml"/>
-        <additional-files value="vtypes.add.xml busstops.add.xml e1detectors.add.xml lust.poly.xml"/>
+        <route-files value="buslines.rou.xml, DUERoutes/local.actuated.0.rou.xml, DUERoutes/local.actuated.1.rou.xml, DUERoutes/local.actuated.2.rou.xml, transit.rou.xml"/>
+        <additional-files value="vtypes.add.xml, busstops.add.xml, e1detectors.add.xml, lust.poly.xml"/>
     </input>
 
     <output>

--- a/scenario/due.static.sumocfg
+++ b/scenario/due.static.sumocfg
@@ -10,8 +10,8 @@ Author: Lara CODECA [codeca@gmail.com]
 
     <input>
         <net-file value="lust.net.xml"/>
-        <route-files value="buslines.rou.xml DUERoutes/local.static.0.rou.xml DUERoutes/local.static.1.rou.xml DUERoutes/local.static.2.rou.xml transit.rou.xml"/>
-        <additional-files value="vtypes.add.xml busstops.add.xml e1detectors.add.xml lust.poly.xml tll.static.xml"/>
+        <route-files value="buslines.rou.xml, DUERoutes/local.static.0.rou.xml, DUERoutes/local.static.1.rou.xml, DUERoutes/local.static.2.rou.xml, transit.rou.xml"/>
+        <additional-files value="vtypes.add.xml, busstops.add.xml, e1detectors.add.xml, lust.poly.xml, tll.static.xml"/>
     </input>
 
     <output>


### PR DESCRIPTION
In order to use LuST with SUMO 1.0.1, the file names in `<route-files>`
and `<additional-files>` in *.sumocfg need to be separated by commas.

I also tested this patch with SUMO 0.32.0 and it works as well.